### PR TITLE
Setup Context7 and DevTools for NextJS

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "enableAllProjectMcpServers": true
+}

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# claude code
+.claude/settings.local.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    },
+    "deepwiki": {
+      "url": "https://mcp.deepwiki.com/sse"
+    },
+    "next-devtools": {
+      "command": "npx",
+      "args": ["-y", "next-devtools-mcp@latest"]
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
4つのMCPサーバー（context7、deepwiki、next-devtools、chrome-devtools）を設定。

設定内容：
- .mcp.json: プロジェクトレベルのMCPサーバー定義
- .claude/settings.json: enableAllProjectMcpServers=true
- .gitignore: .claude/settings.local.jsonを除外

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## what

### asis

<!-- 現在の状態や問題点を記載 -->

### tobe

<!-- 変更後の状態や実装内容を記載 -->

## why

<!-- この変更を行う理由や背景を記載 -->

## ref

<!-- 関連するIssue、ドキュメント、参考URLなどを記載 -->
