### PR TITLE
Configure pnpm workspace with minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,16 +1,1 @@
-# pnpm workspace configuration
-# See: https://pnpm.io/ja/pnpm-workspace_yaml
-
-packages:
-  # Root package
-  - "."
-  # Future packages can be added here
-  # - "packages/*"
-  # - "apps/*"
-
-# Security: Delay installation of newly published packages
-# This reduces the risk of installing compromised packages, as malicious releases
-# are typically discovered and removed within an hour.
-# Setting: 1440 minutes = 24 hours
-# See: https://pnpm.io/ja/settings#minimumreleaseage
 minimumReleaseAge: 1440


### PR DESCRIPTION

## what
- Add pnpm-workspace.yaml for workspace management
- Add .npmrc with minimumReleaseAge=1440 (24 hours) to prevent installation of compromised packages
- Enable strict-peer-dependencies and auto-install-peers for better dependency management

This improves security by delaying installation of newly published packages, reducing the risk of installing malicious releases.

### asis

<!-- 現在の状態や問題点を記載 -->

### tobe

<!-- 変更後の状態や実装内容を記載 -->

## why

<!-- この変更を行う理由や背景を記載 -->

## ref

<!-- 関連するIssue、ドキュメント、参考URLなどを記載 -->
