### PR TITLE
Storybookのブラウザ自動起動を無効化

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,5 +13,8 @@ const config: StorybookConfig = {
     options: {},
   },
   staticDirs: ["../public"],
+  core: {
+    open: false,
+  },
 };
 export default config;


### PR DESCRIPTION

## what

Storybook開発サーバー起動時に自動でブラウザが開かないように設定を追加しました。

### asis

`pnpm storybook`実行時にブラウザが自動で起動される

### tobe

`.storybook/main.ts`に`core.open: false`を設定し、ブラウザの自動起動を無効化

## why

開発環境でStorybookを実行する際、不要なブラウザウィンドウの起動を避けるためです。ブラウザを手動で開きたい場合や、CI/CDパイプラインでStorybookサーバーをバックグラウンドで動作させたい場合に有用です。

## ref

- Storybook Configuration: https://storybook.js.org/docs/get-started/install-and-setup