### PR TITLE
chore: setup Renovate with automerge for minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "description": "Automerge minor and patch updates (except for Next.js and related packages)",
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackageNames": ["next", "@opennextjs/cloudflare"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
- Add renovate.json configuration
- Enable automerge for minor and patch updates
- Exclude Next.js from automerge (requires manual review)
- Set minimum release age to 3 days for stability