### PR TITLE
chore: add zed config

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,50 @@
+{
+  "formatter": "language_server",
+  "format_on_save": "on",
+  "languages": {
+    "JavaScript": {
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "TypeScript": {
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "TSX": {
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    }
+  },
+  "lsp": {
+    "typescript-language-server": {
+      "settings": {
+        "typescript": {
+          "preferences": {
+            "includePackageJsonAutoImports": "on"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## what

Zed EditorのConfigを追加した

### asis

なし

### tobe

あり

## why

最近省メモリの目的でZed editorを使っているため

## ref

- 設定は https://github.com/haydenbleasel/ultracite/blob/main/packages/cli/src/editor-config/zed/default-config.ts を参考にした
- ultraciteがデフォルトで作成してくれるzedのconfig. biomeのautofixなどが組み込まれている。