### PR TITLE
feat: UIコンポーネントのStorybook実装とリファクタリング

### DIFF
--- a/src/components/ui/avatar.stories.tsx
+++ b/src/components/ui/avatar.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Avatar, AvatarFallback, AvatarImage } from "./avatar";
+
+const meta = {
+  title: "UI/Avatar",
+  component: Avatar,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Avatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * 画像付きのデフォルトアバター
+ */
+export const Default: Story = {
+  render: () => (
+    <Avatar>
+      <AvatarImage alt="User Avatar" src="https://github.com/shadcn.png" />
+      <AvatarFallback>CN</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+/**
+ * フォールバック表示のアバター（画像なし）
+ */
+export const Fallback: Story = {
+  render: () => (
+    <Avatar>
+      <AvatarImage alt="User Avatar" src="/broken-image.jpg" />
+      <AvatarFallback>NY</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+/**
+ * 大サイズのアバター
+ */
+export const Large: Story = {
+  render: () => (
+    <Avatar className="size-16">
+      <AvatarImage alt="User Avatar" src="https://github.com/shadcn.png" />
+      <AvatarFallback>CN</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+/**
+ * 小サイズのアバター
+ */
+export const Small: Story = {
+  render: () => (
+    <Avatar className="size-6">
+      <AvatarImage alt="User Avatar" src="https://github.com/shadcn.png" />
+      <AvatarFallback className="text-xs">CN</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+/**
+ * 複数のアバターを並べた表示
+ */
+export const Group: Story = {
+  render: () => (
+    <div className="-space-x-2 flex">
+      <Avatar className="border-2 border-background">
+        <AvatarImage alt="User 1" src="https://github.com/shadcn.png" />
+        <AvatarFallback>U1</AvatarFallback>
+      </Avatar>
+      <Avatar className="border-2 border-background">
+        <AvatarImage alt="User 2" src="https://github.com/vercel.png" />
+        <AvatarFallback>U2</AvatarFallback>
+      </Avatar>
+      <Avatar className="border-2 border-background">
+        <AvatarFallback>+3</AvatarFallback>
+      </Avatar>
+    </div>
+  ),
+};

--- a/src/components/ui/badge.stories.tsx
+++ b/src/components/ui/badge.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Badge } from "./badge";
+
+const meta = {
+  title: "UI/Badge",
+  component: Badge,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "secondary", "destructive", "outline"],
+      description: "バッジのスタイルバリアント",
+    },
+    asChild: {
+      control: "boolean",
+      description: "子要素をルート要素として使用",
+    },
+    children: {
+      control: "text",
+      description: "バッジの内容",
+    },
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * デフォルトのプライマリバッジ
+ */
+export const Default: Story = {
+  args: {
+    variant: "default",
+    children: "Badge",
+  },
+};
+
+/**
+ * セカンダリバッジ
+ */
+export const Secondary: Story = {
+  args: {
+    variant: "secondary",
+    children: "Secondary",
+  },
+};
+
+/**
+ * 破壊的なアクションを示すバッジ
+ */
+export const Destructive: Story = {
+  args: {
+    variant: "destructive",
+    children: "Destructive",
+  },
+};
+
+/**
+ * アウトラインスタイルのバッジ
+ */
+export const Outline: Story = {
+  args: {
+    variant: "outline",
+    children: "Outline",
+  },
+};
+
+/**
+ * 長いテキストを持つバッジ
+ */
+export const LongText: Story = {
+  args: {
+    variant: "default",
+    children: "これは長いテキストのバッジです",
+  },
+};
+
+/**
+ * リンクとして使用するバッジ（asChild）
+ */
+export const AsLink: Story = {
+  render: (args) => (
+    <Badge {...args} asChild>
+      <a href="/example">リンクバッジ</a>
+    </Badge>
+  ),
+  args: {
+    variant: "outline",
+  },
+};

--- a/src/components/ui/button.stories.tsx
+++ b/src/components/ui/button.stories.tsx
@@ -1,6 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { Button } from "./button";
 
+const ChevronRightIcon = () => (
+  <svg
+    fill="none"
+    height="16"
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="2"
+    viewBox="0 0 24 24"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>Chevron Right</title>
+    <polyline points="9 18 15 12 9 6" />
+  </svg>
+);
+
 const meta = {
   title: "UI/Button",
   component: Button,
@@ -132,30 +149,11 @@ export const Large: Story = {
  * アイコンのみのボタン（デフォルトサイズ）
  */
 export const Icon: Story = {
-  render: (args) => {
-    const ChevronRight = () => (
-      <svg
-        fill="none"
-        height="16"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        viewBox="0 0 24 24"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <title>Chevron Right</title>
-        <polyline points="9 18 15 12 9 6" />
-      </svg>
-    );
-
-    return (
-      <Button {...args}>
-        <ChevronRight />
-      </Button>
-    );
-  },
+  render: (args) => (
+    <Button {...args}>
+      <ChevronRightIcon />
+    </Button>
+  ),
   args: {
     variant: "outline",
     size: "icon",
@@ -166,30 +164,11 @@ export const Icon: Story = {
  * アイコンのみのボタン（小サイズ）
  */
 export const IconSmall: Story = {
-  render: (args) => {
-    const ChevronRight = () => (
-      <svg
-        fill="none"
-        height="16"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        viewBox="0 0 24 24"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <title>Chevron Right</title>
-        <polyline points="9 18 15 12 9 6" />
-      </svg>
-    );
-
-    return (
-      <Button {...args}>
-        <ChevronRight />
-      </Button>
-    );
-  },
+  render: (args) => (
+    <Button {...args}>
+      <ChevronRightIcon />
+    </Button>
+  ),
   args: {
     variant: "outline",
     size: "icon-sm",
@@ -200,30 +179,11 @@ export const IconSmall: Story = {
  * アイコンのみのボタン（大サイズ）
  */
 export const IconLarge: Story = {
-  render: (args) => {
-    const ChevronRight = () => (
-      <svg
-        fill="none"
-        height="16"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        viewBox="0 0 24 24"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <title>Chevron Right</title>
-        <polyline points="9 18 15 12 9 6" />
-      </svg>
-    );
-
-    return (
-      <Button {...args}>
-        <ChevronRight />
-      </Button>
-    );
-  },
+  render: (args) => (
+    <Button {...args}>
+      <ChevronRightIcon />
+    </Button>
+  ),
   args: {
     variant: "outline",
     size: "icon-lg",
@@ -234,31 +194,12 @@ export const IconLarge: Story = {
  * テキストとアイコンを組み合わせたボタン
  */
 export const WithIcon: Story = {
-  render: (args) => {
-    const ChevronRight = () => (
-      <svg
-        fill="none"
-        height="16"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        viewBox="0 0 24 24"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <title>Chevron Right</title>
-        <polyline points="9 18 15 12 9 6" />
-      </svg>
-    );
-
-    return (
-      <Button {...args}>
-        {args.children}
-        <ChevronRight />
-      </Button>
-    );
-  },
+  render: (args) => (
+    <Button {...args}>
+      {args.children}
+      <ChevronRightIcon />
+    </Button>
+  ),
   args: {
     variant: "default",
     size: "default",

--- a/src/components/ui/card.stories.tsx
+++ b/src/components/ui/card.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Button } from "./button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./card";
+
+const meta = {
+  title: "UI/Card",
+  component: Card,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * 全ての要素を含んだ完全なカード
+ */
+export const Default: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>カードタイトル</CardTitle>
+        <CardDescription>カードの説明文がここに入ります</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>カードの本文コンテンツです。様々な情報を表示できます。</p>
+      </CardContent>
+      <CardFooter>
+        <Button>アクション</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+/**
+ * ヘッダーのみのシンプルなカード
+ */
+export const HeaderOnly: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>シンプルカード</CardTitle>
+        <CardDescription>ヘッダーのみを持つカードです</CardDescription>
+      </CardHeader>
+    </Card>
+  ),
+};
+
+/**
+ * コンテンツのみのカード
+ */
+export const ContentOnly: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardContent>
+        <p>
+          コンテンツのみを持つカードです。シンプルな情報表示に適しています。
+        </p>
+      </CardContent>
+    </Card>
+  ),
+};
+
+/**
+ * 長いコンテンツを持つカード
+ */
+export const LongContent: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>長いコンテンツのカード</CardTitle>
+        <CardDescription>
+          このカードは長い説明文と本文を含んでいます。レイアウトの確認に使用してください。
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>
+          これは非常に長いコンテンツを持つカードの例です。実際のアプリケーションでは、ブログ記事の抜粋、製品の説明、ユーザープロフィールなど、様々な情報を表示することがあります。カードコンポーネントは柔軟にコンテンツを収容できるよう設計されています。
+        </p>
+      </CardContent>
+      <CardFooter className="justify-between">
+        <Button variant="outline">キャンセル</Button>
+        <Button>保存</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+/**
+ * フッターに複数のボタンを持つカード
+ */
+export const WithMultipleActions: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>確認ダイアログ</CardTitle>
+        <CardDescription>この操作を実行しますか？</CardDescription>
+      </CardHeader>
+      <CardFooter className="justify-end gap-2">
+        <Button variant="outline">キャンセル</Button>
+        <Button variant="destructive">削除</Button>
+      </CardFooter>
+    </Card>
+  ),
+};

--- a/src/components/ui/separator.stories.tsx
+++ b/src/components/ui/separator.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Separator } from "./separator";
+
+const meta = {
+  title: "UI/Separator",
+  component: Separator,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    orientation: {
+      control: "select",
+      options: ["horizontal", "vertical"],
+      description: "区切り線の向き",
+    },
+    decorative: {
+      control: "boolean",
+      description: "装飾目的かどうか（アクセシビリティ用）",
+    },
+  },
+} satisfies Meta<typeof Separator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * 水平方向のデフォルト区切り線
+ */
+export const Horizontal: Story = {
+  render: (args) => (
+    <div className="w-[300px]">
+      <div className="text-sm">上のコンテンツ</div>
+      <Separator {...args} className="my-4" />
+      <div className="text-sm">下のコンテンツ</div>
+    </div>
+  ),
+  args: {
+    orientation: "horizontal",
+  },
+};
+
+/**
+ * 垂直方向の区切り線
+ */
+export const Vertical: Story = {
+  render: (args) => (
+    <div className="flex h-8 items-center gap-4">
+      <span className="text-sm">左</span>
+      <Separator {...args} />
+      <span className="text-sm">右</span>
+    </div>
+  ),
+  args: {
+    orientation: "vertical",
+  },
+};
+
+/**
+ * ナビゲーションでの使用例
+ */
+export const InNavigation: Story = {
+  render: () => (
+    <div className="flex h-8 items-center gap-4">
+      <span className="text-sm">ホーム</span>
+      <Separator orientation="vertical" />
+      <span className="text-sm">ブログ</span>
+      <Separator orientation="vertical" />
+      <span className="text-sm">お問い合わせ</span>
+    </div>
+  ),
+};


### PR DESCRIPTION

Storybook のストーリーが定義されていなかったUIコンポーネント（Badge, Card, Avatar, Separator）について、段階的に実装を開始する。併せて、既存のボタンストーリーのコード重複を解消する。

### asis

Storybook は設定されているものの、28個のコンポーネントのうち3個のみストーリーが定義されており、大多数のコンポーネントは視覚的テストやドキュメント生成の恩恵を受けていない。button.stories.tsx では `ChevronRight` SVG が4回重複定義されており、保守効率が低い状態である。

### tobe

- Badge, Card, Avatar, Separator について、既存ストーリーパターン（JSDoc、autodocs タグ、バリアント例、エッジケース）に準拠したストーリーを新規実装
- button.stories.tsx のアイコン定義を共通化し、DRY 原則に基づいてコード品質を向上

## why

UI コンポーネントのストーリーは、ビジュアルリグレッション検出、ドキュメント自動生成、開発効率向上など複数の価値を提供する。高い再利用性を持つプリミティブコンポーネントから段階的に整備することで、チーム開発における品質とメンテナンス効率を向上させるため。

## ref

- Storybook 設定: `.storybook/main.ts`
- 既存ストーリーパターン: `src/components/ui/button.stories.tsx`（リファクタリング前）