### PR TITLE
feat: ネタバレ警告コンポーネントを追加

### DIFF
--- a/source.config.ts
+++ b/source.config.ts
@@ -29,6 +29,7 @@ export const blog = defineDocs({
         .optional()
         .default([]),
       draft: z.boolean().optional().default(false),
+      spoiler: z.boolean().optional().default(false),
     }),
     postprocess: {
       includeProcessedMarkdown: true,

--- a/src/app/posts/[slug]/components/mdx-components.tsx
+++ b/src/app/posts/[slug]/components/mdx-components.tsx
@@ -4,6 +4,7 @@ import { CodeBlock, Pre } from "fumadocs-ui/components/codeblock";
 import { ImageZoom } from "fumadocs-ui/components/image-zoom";
 import defaultComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { Spoiler } from "@/components/ui/spoiler";
 
 const generator = createGenerator();
 
@@ -19,6 +20,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     AutoTypeTable: (props) => (
       <AutoTypeTable {...props} generator={generator} />
     ),
+    Spoiler,
     ...components,
   };
 }

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { ReadingTime } from "@/components/ui/reading-time";
+import { Spoiler } from "@/components/ui/spoiler";
 import { type BlogPage, blog, getPageImage } from "@/lib/source";
 import { CopyMarkdownButton } from "./components/copy-markdown-button";
 import { getMDXComponents } from "./components/mdx-components";
@@ -75,6 +76,14 @@ export default async function PostPage({ params }: Props) {
               <Badge key={tag}>{tag}</Badge>
             ))}
           </div>
+        )}
+
+        {post.data.spoiler && (
+          <Spoiler
+            className="mt-6"
+            description="この記事にはゲームのストーリーに関するネタバレが含まれています。未クリアの方はご注意ください。"
+            variant="game"
+          />
         )}
       </header>
       <div className="relative z-10 mx-auto flex max-w-7xl px-4 md:px-0">

--- a/src/components/ui/spoiler.stories.tsx
+++ b/src/components/ui/spoiler.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Spoiler } from "./spoiler";
+
+const meta = {
+  title: "UI/Spoiler",
+  component: Spoiler,
+  parameters: {
+    layout: "centered",
+    backgrounds: {
+      default: "dark",
+      values: [{ name: "dark", value: "#2E3440" }],
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "game"],
+      description: "スポイラーのスタイルバリアント",
+    },
+    title: {
+      control: "text",
+      description: "作品名（「〇〇のネタバレ注意」の形式で表示）",
+    },
+    until: {
+      control: "text",
+      description: "ネタバレの範囲（例: 第3章まで、エンディングまで）",
+    },
+    description: {
+      control: "text",
+      description: "カスタム説明文（untilより優先）",
+    },
+  },
+  decorators: [
+    (StoryComponent) => (
+      <div className="w-[500px]">
+        <StoryComponent />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Spoiler>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * デフォルトの警告表示。
+ * シンプルに「ネタバレ注意」と表示されます。
+ */
+export const Default: Story = {
+  args: {
+    variant: "default",
+  },
+};
+
+/**
+ * ゲーム向けバリアント。
+ * 紫のアクセントカラーとゲームコントローラーアイコンで表示されます。
+ */
+export const Game: Story = {
+  args: {
+    variant: "game",
+  },
+};
+
+/**
+ * 作品名を指定した場合。
+ * タイトルが「〇〇のネタバレ注意」に自動変換されます。
+ */
+export const WithTitle: Story = {
+  args: {
+    variant: "game",
+    title: "ゼルダの伝説 ティアーズ オブ ザ キングダム",
+  },
+};
+
+/**
+ * ネタバレの範囲を指定。
+ * 「この記事は〇〇のネタバレを含みます」と表示されます。
+ */
+export const WithUntil: Story = {
+  args: {
+    variant: "game",
+    title: "FF7 リバース",
+    until: "第3章まで",
+  },
+};
+
+/**
+ * エンディングまでのネタバレ警告
+ */
+export const UntilEnding: Story = {
+  args: {
+    variant: "game",
+    title: "ペルソナ5",
+    until: "エンディングまで",
+  },
+};
+
+/**
+ * カスタム説明文を使用
+ */
+export const CustomDescription: Story = {
+  args: {
+    variant: "default",
+    title: "進撃の巨人",
+    description:
+      "この記事には最終話までの重大なネタバレが含まれています。原作未読の方はご注意ください。",
+  },
+};
+
+/**
+ * 映画・ドラマ向け（デフォルトバリアント）
+ */
+export const Movie: Story = {
+  args: {
+    variant: "default",
+    title: "インターステラー",
+    until: "ラストシーンまで",
+  },
+};

--- a/src/components/ui/spoiler.tsx
+++ b/src/components/ui/spoiler.tsx
@@ -1,0 +1,80 @@
+import { Alert02Icon, GameController03Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const spoilerVariants = cva("flex items-start gap-4 rounded-lg border p-4", {
+  variants: {
+    variant: {
+      default: "border-[#EBCB8B]/30 bg-[#EBCB8B]/10",
+      game: "border-[#B48EAD]/30 bg-[#B48EAD]/10",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
+
+const iconColorVariants = {
+  default: "text-[#EBCB8B]",
+  game: "text-[#B48EAD]",
+};
+
+const titleColorVariants = {
+  default: "text-[#EBCB8B]",
+  game: "text-[#B48EAD]",
+};
+
+type SpoilerProps = {
+  /** ネタバレの範囲（例: "第3章まで", "エンディングまで"） */
+  until?: string;
+  /** 作品名（指定すると「〇〇のネタバレ注意」になる） */
+  title?: string;
+  /** カスタム説明文（untilより優先） */
+  description?: string;
+  className?: string;
+} & VariantProps<typeof spoilerVariants>;
+
+export function Spoiler({
+  until,
+  title,
+  description,
+  variant = "default",
+  className,
+}: SpoilerProps) {
+  const IconComponent = variant === "game" ? GameController03Icon : Alert02Icon;
+  const displayTitle = title ? `${title}のネタバレ注意` : "ネタバレ注意";
+  const displayDescription =
+    description ??
+    (until
+      ? `この記事は${until}のネタバレを含みます。`
+      : "この記事にはネタバレが含まれています。");
+
+  return (
+    <div
+      className={cn(spoilerVariants({ variant }), className)}
+      data-slot="spoiler"
+      role="alert"
+    >
+      <HugeiconsIcon
+        className={cn(
+          "mt-0.5 size-6 shrink-0",
+          iconColorVariants[variant ?? "default"]
+        )}
+        icon={IconComponent}
+      />
+      <div className="flex flex-col gap-1">
+        <p
+          className={cn(
+            "font-heading font-semibold text-base",
+            titleColorVariants[variant ?? "default"]
+          )}
+        >
+          {displayTitle}
+        </p>
+        <p className="text-[#D8DEE9] text-sm">{displayDescription}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## what

ゲーム・映画・アニメなどの記事にネタバレ警告を表示できる `Spoiler` コンポーネントを追加。

### asis

ネタバレを含む記事において、読者に事前警告を表示する機能が存在しない。ゲームのストーリー考察や映画レビュー等の記事で、読者が意図せずネタバレに遭遇するリスクがある。

### tobe

- `Spoiler` コンポーネントを実装（2つのバリアント: default/game）
- 記事のフロントマターに `spoiler: true` を指定することで、記事ヘッダーにネタバレ警告を自動表示
- MDX コンテンツ内でも `<Spoiler />` を直接利用可能
- Storybook でコンポーネントのバリエーションを確認可能

## why

ゲームや映画のレビュー・考察記事を執筆する際、読者体験を尊重したネタバレへの配慮が必要。本コンポーネントにより、作品名、ネタバレ範囲（第○章まで、エンディングまで等）、カスタム説明文を柔軟に設定でき、ブログのユーザー体験を向上させる。

## ref

- デザイン: Nord テーマ準拠（Aurora Yellow: #EBCB8B, Aurora Purple: #B48EAD）
- アイコン: Hugeicons（Alert02Icon, GameController03Icon）