### PR TITLE
chore: remove Index navigation link from header

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -32,7 +32,7 @@ export function Header() {
       {/* Nav & Icons & Switcher */}
       <div className="flex items-center gap-6 md:gap-8">
         <nav className="hidden gap-8 font-mono text-muted-foreground text-sm md:flex">
-          {["Index", "Playground", "About"].map((item) => (
+          {["Playground", "About"].map((item) => (
             // biome-ignore lint/a11y/useValidAnchor: TODO: implement page...
             <a className="group relative overflow-hidden" href="#" key={item}>
               <span className="relative z-10 transition-colors duration-300 group-hover:text-primary">


### PR DESCRIPTION
## what

HeaderからIndexページへのナビゲーションリンクを削除した。

### asis

HeaderのナビゲーションにIndexリンクが存在するが、Indexページは実装されていない。

### tobe

Indexリンクを削除し、PlaygroundとAboutのみを表示するようにした。

## why

存在しないページへの導線は不要であるため。

## ref

なし