### PR TITLE
feat: migrate shadcn/ui components from Radix UI to Base UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@orama/orama": "^3.1.16",
     "@orama/stopwords": "^3.1.16",
     "@orama/tokenizers": "^3.1.16",
-    "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@shikijs/rehype": "^3.15.0",
     "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@orama/orama": "^3.1.16",
     "@orama/stopwords": "^3.1.16",
     "@orama/tokenizers": "^3.1.16",
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@shikijs/rehype": "^3.15.0",
     "class-variance-authority": "^0.7.1",
     "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,12 @@
     "textlint:fix": "textlint --fix \"contents/**/*.mdx\""
   },
   "dependencies": {
+    "@base-ui/react": "^1.0.0",
     "@hugeicons/core-free-icons": "^2.0.0",
     "@hugeicons/react": "^1.1.1",
     "@orama/orama": "^3.1.16",
     "@orama/stopwords": "^3.1.16",
     "@orama/tokenizers": "^3.1.16",
-    "@radix-ui/react-avatar": "^1.1.11",
-    "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@shikijs/rehype": "^3.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@orama/tokenizers':
         specifier: ^3.1.16
         version: 3.1.16
-      '@radix-ui/react-use-controllable-state':
-        specifier: ^1.2.2
-        version: 1.2.2(@types/react@19.2.2)(react@19.2.3)
       '@shikijs/rehype':
         specifier: ^3.15.0
         version: 3.15.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.0.0
+        version: 1.0.0(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@hugeicons/core-free-icons':
         specifier: ^2.0.0
         version: 2.0.0
@@ -23,12 +26,6 @@ importers:
       '@orama/tokenizers':
         specifier: ^3.1.16
         version: 3.1.16
-      '@radix-ui/react-avatar':
-        specifier: ^1.1.11
-        version: 1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-separator':
-        specifier: ^1.1.8
-        version: 1.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.2)(react@19.2.3)
@@ -279,6 +276,27 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.0.0':
+    resolution: {integrity: sha512-4USBWz++DUSLTuIYpbYkSgy1F9ZmNG9S/lXvlUN6qMK0P0RlW+6eQmDUB4DgZ7HVvtXl4pvi4z5J2fv6Z3+9hg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui/utils@0.2.3':
+    resolution: {integrity: sha512-/CguQ2PDaOzeVOkllQR8nocJ0FFIDqsWIcURsVmm53QGo8NhFNpePjNlyPIB41luxfOqnG7PU0xicMEw3ls7XQ==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@biomejs/biome@2.3.4':
     resolution: {integrity: sha512-TU08LXjBHdy0mEY9APtEtZdNQQijXUDSXR7IK1i45wgoPD5R0muK7s61QcFir6FpOj/RP1+YkPx5QJlycXUU3w==}
@@ -1044,19 +1062,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-avatar@1.1.11':
-    resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-collapsible@1.1.12':
     resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
@@ -1094,15 +1099,6 @@ packages:
 
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-context@1.1.3':
-    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1254,19 +1250,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-primitive@2.1.4':
-    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -1282,19 +1265,6 @@ packages:
 
   '@radix-ui/react-scroll-area@1.2.10':
     resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-separator@1.1.8':
-    resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1366,15 +1336,6 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-is-hydrated@0.1.0':
-    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4345,6 +4306,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -4622,6 +4586,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tabbable@6.3.0:
+    resolution: {integrity: sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==}
 
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
@@ -5376,6 +5343,31 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@base-ui/react@1.0.0(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@base-ui/utils': 0.2.3(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@floating-ui/utils': 0.2.10
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      reselect: 5.1.1
+      tabbable: 6.3.0
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.2
+
+  '@base-ui/utils@0.2.3(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@floating-ui/utils': 0.2.10
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   '@biomejs/biome@2.3.4':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.3.4
@@ -5937,19 +5929,6 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
-  '@radix-ui/react-avatar@1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-context': 1.1.3(@types/react@19.2.2)(react@19.2.3)
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.3)
-      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.2)(react@19.2.3)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.2
-      '@types/react-dom': 19.2.2(@types/react@19.2.2)
-
   '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -5985,12 +5964,6 @@ snapshots:
       '@types/react': 19.2.2
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.2)(react@19.2.3)':
-    dependencies:
-      react: 19.2.3
-    optionalDependencies:
-      '@types/react': 19.2.2
-
-  '@radix-ui/react-context@1.1.3(@types/react@19.2.2)(react@19.2.3)':
     dependencies:
       react: 19.2.3
     optionalDependencies:
@@ -6153,15 +6126,6 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
-  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.2)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.2
-      '@types/react-dom': 19.2.2(@types/react@19.2.2)
-
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -6190,15 +6154,6 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.3)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.2
-      '@types/react-dom': 19.2.2(@types/react@19.2.2)
-
-  '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
@@ -6260,13 +6215,6 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.3)
       react: 19.2.3
-    optionalDependencies:
-      '@types/react': 19.2.2
-
-  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.2)(react@19.2.3)':
-    dependencies:
-      react: 19.2.3
-      use-sync-external-store: 1.6.0(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.2
 
@@ -9923,6 +9871,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  reselect@5.1.1: {}
+
   resolve-pkg-maps@1.0.0:
     optional: true
 
@@ -10324,6 +10274,8 @@ snapshots:
     optional: true
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tabbable@6.3.0: {}
 
   table@6.9.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@orama/tokenizers':
         specifier: ^3.1.16
         version: 3.1.16
-      '@radix-ui/react-slot':
-        specifier: ^1.2.4
-        version: 1.2.4(@types/react@19.2.2)(react@19.2.3)
       '@radix-ui/react-use-controllable-state':
         specifier: ^1.2.2
         version: 1.2.2(@types/react@19.2.2)(react@19.2.3)

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,19 +1,33 @@
 "use client";
 
-import {
-  Fallback as AvatarPrimitiveFallback,
-  Image as AvatarPrimitiveImage,
-  Root as AvatarPrimitiveRoot,
-} from "@radix-ui/react-avatar";
+import { Avatar as BaseAvatar } from "@base-ui/react/avatar";
 
 import { cn } from "@/lib/utils";
 
-function Avatar({
-  className,
-  ...props
-}: React.ComponentProps<typeof AvatarPrimitiveRoot>) {
+type AvatarProps = Omit<
+  React.ComponentProps<typeof BaseAvatar.Root>,
+  "className"
+> & {
+  className?: string;
+};
+
+type AvatarImageProps = Omit<
+  React.ComponentProps<typeof BaseAvatar.Image>,
+  "className"
+> & {
+  className?: string;
+};
+
+type AvatarFallbackProps = Omit<
+  React.ComponentProps<typeof BaseAvatar.Fallback>,
+  "className"
+> & {
+  className?: string;
+};
+
+function Avatar({ className, ...props }: AvatarProps) {
   return (
-    <AvatarPrimitiveRoot
+    <BaseAvatar.Root
       className={cn(
         "relative flex size-8 shrink-0 overflow-hidden rounded-full",
         className
@@ -24,12 +38,9 @@ function Avatar({
   );
 }
 
-function AvatarImage({
-  className,
-  ...props
-}: React.ComponentProps<typeof AvatarPrimitiveImage>) {
+function AvatarImage({ className, ...props }: AvatarImageProps) {
   return (
-    <AvatarPrimitiveImage
+    <BaseAvatar.Image
       className={cn("aspect-square size-full", className)}
       data-slot="avatar-image"
       {...props}
@@ -37,12 +48,9 @@ function AvatarImage({
   );
 }
 
-function AvatarFallback({
-  className,
-  ...props
-}: React.ComponentProps<typeof AvatarPrimitiveFallback>) {
+function AvatarFallback({ className, ...props }: AvatarFallbackProps) {
   return (
-    <AvatarPrimitiveFallback
+    <BaseAvatar.Fallback
       className={cn(
         "flex size-full items-center justify-center rounded-full bg-muted",
         className

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,4 +1,3 @@
-import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
@@ -25,17 +24,22 @@ const badgeVariants = cva(
   }
 );
 
-function Badge({
+type BadgeProps<T extends React.ElementType = "span"> = {
+  as?: T;
+  className?: string;
+  variant?: VariantProps<typeof badgeVariants>["variant"];
+} & Omit<React.ComponentPropsWithoutRef<T>, "as" | "className">;
+
+function Badge<T extends React.ElementType = "span">({
+  as,
   className,
   variant,
-  asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span";
+}: BadgeProps<T>) {
+  const Component = as || "span";
 
   return (
-    <Comp
+    <Component
       className={cn(badgeVariants({ variant }), className)}
       data-slot="badge"
       {...props}

--- a/src/components/ui/section-header.tsx
+++ b/src/components/ui/section-header.tsx
@@ -1,36 +1,38 @@
 import type { IconSvgElement } from "@hugeicons/react";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Slot } from "@radix-ui/react-slot";
+import type React from "react";
 import { cn } from "@/lib/utils";
 
-type SectionHeaderProps = {
+type SectionHeaderProps<T extends React.ElementType = "h2"> = {
+  as?: T;
   icon?: IconSvgElement;
   iconSize?: number;
   children: React.ReactNode;
   className?: string;
-  asChild?: boolean;
-};
+} & Omit<React.ComponentPropsWithoutRef<T>, "as" | "className">;
 
-export function SectionHeader({
+export function SectionHeader<T extends React.ElementType = "h2">({
+  as,
   icon,
   iconSize = 24,
   children,
   className,
-  asChild = false,
-}: SectionHeaderProps) {
-  const Comp = asChild ? Slot : "h2";
+  ...props
+}: SectionHeaderProps<T>) {
+  const Component = as || "h2";
 
   return (
-    <Comp
+    <Component
       className={cn(
         "flex items-center gap-3 font-semibold text-2xl text-foreground md:text-3xl",
         className
       )}
+      {...props}
     >
       {icon && (
         <HugeiconsIcon className="text-primary" icon={icon} size={iconSize} />
       )}
       {children}
-    </Comp>
+    </Component>
   );
 }

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,23 +1,28 @@
 "use client";
 
-import { Root as SeparatorPrimitiveRoot } from "@radix-ui/react-separator";
+import { Separator as BaseSeparator } from "@base-ui/react/separator";
 import type * as React from "react";
 import { cn } from "@/lib/utils";
+
+type SeparatorProps = Omit<
+  React.ComponentProps<typeof BaseSeparator>,
+  "className"
+> & {
+  className?: string;
+};
 
 function Separator({
   className,
   orientation = "horizontal",
-  decorative = true,
   ...props
-}: React.ComponentProps<typeof SeparatorPrimitiveRoot>) {
+}: SeparatorProps) {
   return (
-    <SeparatorPrimitiveRoot
+    <BaseSeparator
       className={cn(
         "fade-in slide-in-from-bottom-5 shrink-0 animate-in bg-linear-to-r from-transparent via-border to-transparent delay-300 duration-800 data-[orientation=horizontal]:h-px data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px",
         className
       )}
       data-slot="separator"
-      decorative={decorative}
       orientation={orientation}
       {...props}
     />

--- a/src/components/ui/theme-switcher.tsx
+++ b/src/components/ui/theme-switcher.tsx
@@ -6,10 +6,10 @@ import {
   Sun03Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { motion } from "motion/react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useState } from "react";
+import { useControllableState } from "@/hooks/use-controllable-state";
 import { cn } from "@/lib/utils";
 
 const themes = [

--- a/src/hooks/use-controllable-state.ts
+++ b/src/hooks/use-controllable-state.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+
+type UseControllableStateParams<T> = {
+  prop?: T;
+  defaultProp?: T;
+  onChange?: (value: T) => void;
+};
+
+/**
+ * Custom hook for managing controllable state.
+ * Supports both controlled and uncontrolled component patterns.
+ *
+ * @param prop - The controlled value (when provided, component is controlled)
+ * @param defaultProp - The default value for uncontrolled mode
+ * @param onChange - Callback fired when the state changes
+ * @returns A tuple of [state, setState]
+ */
+export function useControllableState<T>({
+  prop,
+  defaultProp,
+  onChange,
+}: UseControllableStateParams<T>): [T | undefined, (value: T) => void] {
+  const [uncontrolledState, setUncontrolledState] = useState(defaultProp);
+  const isControlled = prop !== undefined;
+  const state = isControlled ? prop : uncontrolledState;
+
+  const setState = useCallback(
+    (nextValue: T) => {
+      if (!isControlled) {
+        setUncontrolledState(nextValue);
+      }
+      onChange?.(nextValue);
+    },
+    [isControlled, onChange]
+  );
+
+  return [state, setState];
+}


### PR DESCRIPTION
## what

shadcn/uiベースのUIコンポーネントを、Radix UIからMUIのBase UIに移行した。

### asis

- shadcn/uiコンポーネントはRadix UIプリミティブをベースに実装されていた
- 以下のRadix UIパッケージに依存:
  - `@radix-ui/react-avatar`
  - `@radix-ui/react-separator`
  - `@radix-ui/react-slot`
  - `@radix-ui/react-use-controllable-state`

### tobe

- `@base-ui/react` 1.0.0に移行
- 全Radix UI依存を削除
- Slot機能は `as` prop パターンで置き換え
- `useControllableState` は自前実装に置き換え

## why

Base UIはMUIチームが開発するヘッドレスUIライブラリで、以下のメリットがある:

1. **スタイリングの自由度**: Radix UIと同様にヘッドレスだが、より柔軟なカスタマイズが可能
2. **MUIエコシステムとの親和性**: 将来的にMUIとの統合が容易
3. **アクセシビリティ**: WAI-ARIAに準拠した堅牢なアクセシビリティ実装
4. **バンドルサイズ**: よりモダンな実装でパフォーマンスが向上

また、React 19の`ref` as propsパターンに対応するため、`forwardRef`を使用しない実装に移行できた。

## 変更内容

### 移行したコンポーネント

- **Avatar** (`@radix-ui/react-avatar` → `@base-ui/react/avatar`)
- **Badge** (`@radix-ui/react-slot` → `as` prop)
- **SectionHeader** (`@radix-ui/react-slot` → `as` prop)
- **Separator** (`@radix-ui/react-separator` → `@base-ui/react/separator`)

### 追加実装

- **useControllableState** hook: `@radix-ui/react-use-controllable-state` の代替として自前実装

### ファイル変更統計

```
package.json                         |   5 +-
pnpm-lock.yaml                       | 172 ++++++++++++-----------------------
src/components/ui/avatar.tsx         |  48 ++++++----
src/components/ui/badge.tsx          |  18 ++--
src/components/ui/section-header.tsx |  22 +++--
src/components/ui/separator.tsx      |  15 ++-
src/components/ui/theme-switcher.tsx |   2 +-
src/hooks/use-controllable-state.ts  |  38 ++++++++
8 files changed, 160 insertions(+), 160 deletions(-)
```

## ref

- [Base UI Documentation](https://base-ui.com/)
- [Radix UI to Base UI Migration](https://base-ui.com/getting-started/migration/)

## Test plan

- [ ] `pnpm build` が成功することを確認
- [ ] `pnpm typecheck` でエラーがないことを確認
- [ ] `pnpm lint` でエラーがないことを確認
- [ ] すべてのUIコンポーネントが正常に表示されることを確認
- [ ] アクセシビリティが維持されていることを確認